### PR TITLE
fix: create_apps.sh template path

### DIFF
--- a/scripts/create_apps.sh
+++ b/scripts/create_apps.sh
@@ -23,7 +23,7 @@ while IFS= read -r APP || [ -n "$APP" ]; do
     echo "Skipping $APP (already exists)"
   else
     echo "Creating $APP..."
-    npx create-expo-app "$APP" --template
+    npx create-expo-app "$APP" --template expo-template-blank-typescript
     echo "$APP created"
   fi
   echo


### PR DESCRIPTION
## Summary
- specify expo template to fix app creation script

## Testing
- `bash scripts/create_apps.sh` *(fails: network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6873ccd719c4833290841e4b6165a3d8