### PR TITLE
feat: moodcraft initial implementation

### DIFF
--- a/generated/moodcraft/App.tsx
+++ b/generated/moodcraft/App.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import RootNavigator from './src/navigation';
+
+export default function App() {
+  return (
+    <SafeAreaProvider>
+      <NavigationContainer>
+        <RootNavigator />
+      </NavigationContainer>
+    </SafeAreaProvider>
+  );
+}

--- a/generated/moodcraft/README.md
+++ b/generated/moodcraft/README.md
@@ -1,0 +1,10 @@
+# MoodCraft
+
+AI-powered mood tracking with personalized meditation generation using on-device ML models.
+
+## Development
+
+```bash
+yarn install
+expo start
+```

--- a/generated/moodcraft/app.json
+++ b/generated/moodcraft/app.json
@@ -1,0 +1,9 @@
+{
+  "expo": {
+    "name": "MoodCraft",
+    "slug": "moodcraft",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "jsEngine": "hermes"
+  }
+}

--- a/generated/moodcraft/babel.config.js
+++ b/generated/moodcraft/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/generated/moodcraft/index.ts
+++ b/generated/moodcraft/index.ts
@@ -1,0 +1,4 @@
+import { registerRootComponent } from 'expo';
+import App from './App';
+
+registerRootComponent(App);

--- a/generated/moodcraft/package.json
+++ b/generated/moodcraft/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "moodcraft",
+  "version": "1.0.0",
+  "main": "index.ts",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "~53.0.17",
+    "react": "19.0.0",
+    "react-native": "0.79.5",
+    "@react-navigation/native": "^7.1.14",
+    "@react-navigation/native-stack": "^7.7.5",
+    "react-native-screens": "^4.11.1",
+    "react-native-safe-area-context": "^5.5.2",
+    "react-native-gesture-handler": "^2.27.1",
+    "react-native-reanimated": "^3.18.0",
+    "react-native-iap": "^12.19.0",
+    "expo-asset": "~8.16.1",
+    "expo-sqlite": "~12.6.0",
+    "react-native-mmkv": "^2.11.0",
+    "react-native-fast-tflite": "^1.0.3",
+    "react-native-ml-kit": "^0.3.3"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.25.2",
+    "@types/react": "~19.0.10",
+    "typescript": "~5.8.3"
+  },
+  "private": true,
+  "packageManager": "yarn@4.9.1"
+}

--- a/generated/moodcraft/src/components/PrimaryButton.tsx
+++ b/generated/moodcraft/src/components/PrimaryButton.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Pressable, Text, StyleSheet } from 'react-native';
+
+type Props = {
+  title: string;
+  onPress: () => void;
+};
+
+export default function PrimaryButton({ title, onPress }: Props) {
+  return (
+    <Pressable onPress={onPress} style={styles.btn}>
+      <Text style={styles.text}>{title}</Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  btn: {
+    padding: 12,
+    backgroundColor: '#4f46e5',
+    borderRadius: 8,
+  },
+  text: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+});

--- a/generated/moodcraft/src/navigation/index.tsx
+++ b/generated/moodcraft/src/navigation/index.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import HomeScreen from '../screens/HomeScreen';
+import SettingsScreen from '../screens/SettingsScreen';
+
+export type RootStackParamList = {
+  Home: undefined;
+  Settings: undefined;
+};
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+export default function RootNavigator() {
+  return (
+    <Stack.Navigator initialRouteName="Home">
+      <Stack.Screen name="Home" component={HomeScreen} />
+      <Stack.Screen name="Settings" component={SettingsScreen} />
+    </Stack.Navigator>
+  );
+}

--- a/generated/moodcraft/src/screens/HomeScreen.tsx
+++ b/generated/moodcraft/src/screens/HomeScreen.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { View, Text, Button } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../navigation';
+
+export default function HomeScreen() {
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>MoodCraft</Text>
+      <Button title="Settings" onPress={() => navigation.navigate('Settings')} />
+    </View>
+  );
+}

--- a/generated/moodcraft/src/screens/SettingsScreen.tsx
+++ b/generated/moodcraft/src/screens/SettingsScreen.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function SettingsScreen() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Settings</Text>
+    </View>
+  );
+}

--- a/generated/moodcraft/src/services/iap.ts
+++ b/generated/moodcraft/src/services/iap.ts
@@ -1,0 +1,11 @@
+import * as RNIap from 'react-native-iap';
+
+export const products = ['Premium_Insights', 'Mood_Themes'];
+
+export async function initConnection() {
+  return RNIap.initConnection();
+}
+
+export async function getProducts() {
+  return RNIap.getProducts(products);
+}

--- a/generated/moodcraft/src/services/storage.ts
+++ b/generated/moodcraft/src/services/storage.ts
@@ -1,0 +1,11 @@
+import { MMKV } from 'react-native-mmkv';
+import * as SQLite from 'expo-sqlite';
+
+export const storage = new MMKV();
+const db = SQLite.openDatabase('moodcraft.db');
+
+export function initDb() {
+  db.transaction(tx => {
+    tx.executeSql('CREATE TABLE IF NOT EXISTS entries (id INTEGER PRIMARY KEY NOT NULL, text TEXT)');
+  });
+}

--- a/generated/moodcraft/src/store/useStore.ts
+++ b/generated/moodcraft/src/store/useStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand';
+
+type State = {
+  count: number;
+  increment: () => void;
+};
+
+export const useStore = create<State>(set => ({
+  count: 0,
+  increment: () => set(state => ({ count: state.count + 1 })),
+}));

--- a/generated/moodcraft/tsconfig.json
+++ b/generated/moodcraft/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "strictNullChecks": true
+  }
+}


### PR DESCRIPTION
## Summary
- add MoodCraft Expo app with basic navigation, store, and services

## Testing
- `yarn install`
- `expo start`


------
https://chatgpt.com/codex/tasks/task_e_6877bace0fc08332b9b7dddf043d9cfe